### PR TITLE
feat: 根据不同语言选择不同的自定义代码模板 (#732)

### DIFF
--- a/src/main/java/com/shuzijun/leetcode/plugin/manager/CodeManager.java
+++ b/src/main/java/com/shuzijun/leetcode/plugin/manager/CodeManager.java
@@ -51,7 +51,7 @@ public class CodeManager {
             try{
                 question.setLangSlug(codeTypeEnum.getLangSlug());
                 question.setContent(CommentUtils.createComment(content, codeTypeEnum, config));
-                FileUtils.saveFile(file, VelocityUtils.convert(config.getCustomTemplate(), question));
+                FileUtils.saveFile(file, VelocityUtils.convert(config.getLangCustomTemplate(config.getCodeType()), question));
                 FileUtils.openFileEditorAndSaveState(file, project, question, fillPath, true);
             }finally {
                 question.setContent(content);

--- a/src/main/java/com/shuzijun/leetcode/plugin/model/Config.java
+++ b/src/main/java/com/shuzijun/leetcode/plugin/model/Config.java
@@ -4,6 +4,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.util.xmlb.annotations.Transient;
 import com.shuzijun.leetcode.plugin.utils.MessageUtils;
 import com.shuzijun.leetcode.plugin.utils.PropertiesUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 
 import java.awt.*;
@@ -66,8 +67,9 @@ public class Config implements Cloneable {
      * 自定义代码生成
      */
     private Boolean customCode = false;
+
     /**
-     * 适应英文描述
+     * 使用英文描述
      */
     private Boolean englishContent = false;
 
@@ -78,7 +80,13 @@ public class Config implements Cloneable {
     /**
      * 自定义代码
      */
+    @Deprecated
+    @Transient
     private String customTemplate = Constant.CUSTOM_TEMPLATE;
+
+
+    private Map<String, String> langCustomTemplate = new HashMap<>();
+
     /**
      * 用户cookie
      */
@@ -234,16 +242,39 @@ public class Config implements Cloneable {
         this.customFileName = customFileName;
     }
 
+    @Deprecated
     public String getCustomTemplate() {
+        return customTemplate;
+    }
+
+    @Deprecated
+    public void setCustomTemplate(String customTemplate) {
+        this.customTemplate = customTemplate;
+    }
+
+    public Map<String, String> getLangCustomTemplate() {
+        return langCustomTemplate;
+    }
+
+    public void setLangCustomTemplate(Map<String, String> langCustomTemplate) {
+        this.langCustomTemplate = langCustomTemplate;
+    }
+
+    public String getLangCustomTemplate(String codeType) {
         if (!customCode) {
             return Constant.CUSTOM_TEMPLATE;
         } else {
-            return customTemplate;
+            return langCustomTemplate.getOrDefault(codeType, Constant.CUSTOM_TEMPLATE);
         }
     }
 
-    public void setCustomTemplate(String customTemplate) {
-        this.customTemplate = customTemplate;
+    public void setLangCustomTemplate(String codeType, String customTemplate) {
+        System.out.println("setLangCustomTemplate: " + codeType + " " + customTemplate);
+        if (StringUtils.isBlank(customTemplate)) {
+            this.langCustomTemplate.remove(codeType);
+        } else {
+            this.langCustomTemplate.put(codeType, customTemplate);
+        }
     }
 
     public Map<String, String> getUserCookie() {
@@ -446,7 +477,7 @@ public class Config implements Cloneable {
                 .append(customCode, config.customCode)
                 .append(englishContent, config.englishContent)
                 .append(customFileName, config.customFileName)
-                .append(customTemplate, config.customTemplate)
+                .append(langCustomTemplate, config.langCustomTemplate)
                 .append(levelColour, config.levelColour)
                 .append(cookie, config.cookie)
                 .append(questionEditor, config.questionEditor)
@@ -467,5 +498,11 @@ public class Config implements Cloneable {
         } catch (CloneNotSupportedException ignore) {
         }
         return config;
+    }
+
+    public void printLangCustomTemplate() {
+        for (Map.Entry<String, String> entry : langCustomTemplate.entrySet()) {
+            System.out.println(entry.getKey() + " :\n " + entry.getValue());
+        }
     }
 }

--- a/src/main/java/com/shuzijun/leetcode/plugin/model/Constant.java
+++ b/src/main/java/com/shuzijun/leetcode/plugin/model/Constant.java
@@ -73,6 +73,8 @@ public class Constant {
     public static final Integer PLUGIN_CONFIG_VERSION_2 = 2;
     //第三版本，域名更新，需要将cookie更改一下域名
     public static final Integer PLUGIN_CONFIG_VERSION_3 = 3;
+    //第四版本，不同语言有各自的自定义代码模板
+    public static final Integer PLUGIN_CONFIG_VERSION_4 = 4;
 
     /**
      * 默认题目颜色

--- a/src/main/java/com/shuzijun/leetcode/plugin/setting/PersistentConfig.java
+++ b/src/main/java/com/shuzijun/leetcode/plugin/setting/PersistentConfig.java
@@ -52,20 +52,37 @@ public class PersistentConfig implements PersistentStateComponent<PersistentConf
     @Nullable
     public Config getInitConfig() {
         Config config = initConfig.get(INITNAME);
-        if (config != null && config.getVersion() != null && config.getVersion() < Constant.PLUGIN_CONFIG_VERSION_3) {
-            if (URLUtils.leetcodecnOld.equals(config.getUrl())) {
-                config.setUrl(URLUtils.leetcodecn);
-            }
-            Iterator<String> iterator = config.getUserCookie().keySet().iterator();
-            while (iterator.hasNext()) {
-                String key = iterator.next();
-                String value = config.getCookie(key);
-                if (StringUtils.isBlank(value) || key.startsWith(URLUtils.leetcodecnOld)) {
-                    iterator.remove();
+        if (config != null && config.getVersion() != null) {
+            if (config.getVersion() < Constant.PLUGIN_CONFIG_VERSION_3) {
+                if (URLUtils.leetcodecnOld.equals(config.getUrl())) {
+                    config.setUrl(URLUtils.leetcodecn);
                 }
+                Iterator<String> iterator = config.getUserCookie().keySet().iterator();
+                while (iterator.hasNext()) {
+                    String key = iterator.next();
+                    String value = config.getCookie(key);
+                    if (StringUtils.isBlank(value) || key.startsWith(URLUtils.leetcodecnOld)) {
+                        iterator.remove();
+                    }
+                }
+                config.setVersion(Constant.PLUGIN_CONFIG_VERSION_3);
+                setInitConfig(config);
             }
-            config.setVersion(Constant.PLUGIN_CONFIG_VERSION_3);
-            setInitConfig(config);
+            if (config.getVersion() < Constant.PLUGIN_CONFIG_VERSION_4) {
+                System.out.println("1 version < 4");
+                config.printLangCustomTemplate();
+
+                String codeType = config.getCodeType();
+                System.out.println("2 version < 4");
+                String legacy = config.getCustomTemplate();
+                System.out.println("3 version < 4");
+                config.setLangCustomTemplate(codeType,legacy);
+                System.out.println("4 version < 4");
+                config.setVersion(Constant.PLUGIN_CONFIG_VERSION_4);
+                System.out.println("5 version < 4");
+                setInitConfig(config);
+                config.printLangCustomTemplate();
+            }
         }
         return config;
     }

--- a/src/main/java/com/shuzijun/leetcode/plugin/utils/SentryUtils.java
+++ b/src/main/java/com/shuzijun/leetcode/plugin/utils/SentryUtils.java
@@ -73,7 +73,7 @@ public class SentryUtils {
             userConfig.put("proxy", config.getProxy());
             userConfig.put("customCode", config.getCustomCode());
             userConfig.put("customFileName", config.getCustomFileName());
-            userConfig.put("customTemplate", config.getCustomTemplate());
+            userConfig.put("customTemplate", config.getLangCustomTemplate(config.getCodeType()));
             userBuilder.setData(userConfig);
             context.setUser(userBuilder.build());
 


### PR DESCRIPTION
## 根据不同语言选择不用的自定义代码模板

### 主要改动
- 不同语言对应不同的自定义代码模板
- 支持一次对多个语言的自定义模板的修改和保存
- 支持旧版本

### 关联 Issue
Closes #732  

### 其他信息
因为留意到这个插件似乎挺久没有更新了，而我并不会插件开发（甚至对Java都不太熟悉），所以这个解决方案可能并不优雅。

